### PR TITLE
Add support for providing alt text

### DIFF
--- a/server.js
+++ b/server.js
@@ -185,6 +185,9 @@ app.post('/post', requireLogin, (request, response) => {
   if (request.body.inReplyTo && request.body.inReplyTo.length != 0) {
     params['in-reply-to'] = request.body.inReplyTo
   }
+  if (request.body.altText && request.body.altText.length != 0) {
+    params['mp-photo-alt'] = request.body.altText
+  }
   const micropub = new Micropub({
     token: request.session.user.token,
     micropubEndpoint: request.session.user.micropubEndpoint

--- a/server.js
+++ b/server.js
@@ -178,18 +178,18 @@ app.get('/preview/:id', requireGfycatToken, (request, response) => {
 
 /* Login needed here */
 app.post('/post', requireLogin, (request, response) => {
-  var props = { photo: [ request.body.originalUrl ] }
+  var params = {
+    h: 'entry',
+    photo: request.body.originalUrl
+  }
   if (request.body.inReplyTo) {
-    props['in-reply-to'] = [ request.body.inReplyTo ]
+    params['in-reply-to'] = request.body.inReplyTo
   }
   const micropub = new Micropub({
     token: request.session.user.token,
     micropubEndpoint: request.session.user.micropubEndpoint
   })
-  micropub.create({
-    type: ['h-entry'],
-    properties: props
-  })
+  micropub.create(params, 'form')
   .then((url) => response.redirect(url))
   .catch((err) => console.log(err))
 })

--- a/server.js
+++ b/server.js
@@ -182,7 +182,7 @@ app.post('/post', requireLogin, (request, response) => {
     h: 'entry',
     photo: request.body.originalUrl
   }
-  if (request.body.inReplyTo) {
+  if (request.body.inReplyTo && request.body.inReplyTo.length != 0) {
     params['in-reply-to'] = request.body.inReplyTo
   }
   const micropub = new Micropub({

--- a/views/preview.hbs
+++ b/views/preview.hbs
@@ -19,6 +19,7 @@
         </label>
 
         <input type="hidden" name="originalUrl" value="{{ content_urls.largeGif.url }}" />
+        <input type="text" name="altText" placeholder="Alt text for the GIF, increase the accessibility of the post" />
         {{#if ../inReplyTo }}<input type="hidden" name="inReplyTo" value="{{ ../inReplyTo }}" />{{/if}}
         <input id="post-gif" type="submit" value="Post this GIF" />
       </form>


### PR DESCRIPTION
To make published GIFs, via Micropub, more accessible, we should allow
alt text to be added to the images.

As per conversation on #3, this can't be reliably done through the
Gfycat API, so we should instead allow the user to provide this
information.

As we're using a JSON post, we need to construct an object for the
photo property as per https://micropub.spec.indieweb.org/#json-syntax

Closes #3.

---

I've not been able to test it as I've not gone through the process to set up with a Gfycat OAuth2 consumer, would you prefer that before we merge?